### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a **React Native 0.85** app (`RNTS-Template`). The cloud VM is headless Linux, so the
+**Android app and iOS app cannot be launched** here (no emulator/simulator; iOS additionally needs
+macOS + Xcode). The runnable development surface in this environment is the **Metro bundler**.
+
+### Install
+- Use `npm install --legacy-peer-deps`. The flag is required: `react-native-reanimated` declares a
+  peer on `react-native-worklets@0.9.x` while the repo pins `^0.8.1`, so a plain `npm install` fails
+  with `ERESOLVE`. There is no committed lockfile.
+- `package.json` scripts reference `bun`/`bunx` (e.g. `start:development`), but `bun` is not required
+  for the dev loop — `npm`/`npx` work fine.
+- No `.env` file is needed: the `@env` alias (react-native-dotenv) is only referenced in
+  `babel.config.js` and is not imported anywhere under `src/`.
+
+### Run (dev server)
+- `npm start` launches Metro on `http://localhost:8081`.
+- Verify it is live: `curl http://localhost:8081/status` → `packager-status:running`.
+- Force a full app compile / fetch the JS bundle:
+  `curl "http://localhost:8081/index.bundle?platform=android&dev=true"` (returns ~17 MB).
+- To produce a standalone bundle without the server:
+  `npx react-native bundle --platform android --dev true --entry-file index.js --bundle-output /tmp/index.android.bundle --assets-dest /tmp/rnbundle-assets`
+
+### Known broken checks (upstream/repo issues, not environment problems)
+- `npm run lint` fails: `@react-native/eslint-config@0.85` pulls `eslint-plugin-ft-flow@2.x`, which
+  only supports ESLint 8 (`context.getAllComments is not a function`), but the repo pins ESLint 9.
+  This breaks both legacy and flat config modes. Don't try to "fix the environment" for this.
+- `npm test` (Jest) fails on the single committed `__tests__/App.test.tsx`: it renders the full
+  `<App />`, and the `@react-native/jest-preset` `transformIgnorePatterns` does not transform the
+  ESM-only deps it pulls in (`@sentry/react-native`, `react-redux`, etc.). This is a repo config gap.
+- There is no `typecheck` script. `npx tsc --noEmit` runs but reports pre-existing source-level type
+  errors in `src/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for this React Native 0.85 template in the Cursor Cloud (headless Linux) VM, and adds `AGENTS.md` with durable, non-obvious notes for future agents.

## What was verified

- **Install:** `npm install --legacy-peer-deps` (the flag is required due to a `react-native-reanimated` ↔ `react-native-worklets` peer conflict; no lockfile is committed).
- **Run / dev server:** `npm start` (Metro on `:8081`). Confirmed live via `curl http://localhost:8081/status` and served the full app bundle (HTTP 200, ~17.7 MB) from `/index.bundle?platform=android&dev=true`.
- **Standalone bundle:** `npx react-native bundle --platform android ...` compiled the entire app successfully (17 MB, 37 assets).

## Known repo/upstream issues (documented, not fixed)

- `npm run lint` fails: `@react-native/eslint-config@0.85` pulls `eslint-plugin-ft-flow@2.x` (ESLint 8 only) while the repo pins ESLint 9.
- `npm test` fails on the committed `App.test.tsx`: jest preset `transformIgnorePatterns` doesn't transform ESM-only deps (`@sentry/react-native`, `react-redux`, …).
- No `typecheck` script; `npx tsc --noEmit` reports pre-existing source type errors.

No application code was modified.

## Update script

`npm install --legacy-peer-deps`

[metro_dev_server.log](https://cursor.com/agents/bc-ccc74e1b-58a4-4005-ab91-d0a5e7d49413/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmetro_dev_server.log)
[metro_bundle_verification.txt](https://cursor.com/agents/bc-ccc74e1b-58a4-4005-ab91-d0a5e7d49413/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmetro_bundle_verification.txt)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccc74e1b-58a4-4005-ab91-d0a5e7d49413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccc74e1b-58a4-4005-ab91-d0a5e7d49413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive setup guide for Cursor Cloud environments with React Native 0.85 projects, including installation instructions and a list of known issues with workarounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->