### PR TITLE
chore(structure): typecheck script and navigation typing cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start:development": "APP_ENV=development bunx react-native start",
     "start:production": "APP_ENV=production bunx react-native start",
     "test": "jest",
+    "typecheck": "tsc --noEmit",
     "copy-fonts": "node scripts/copy-fonts.js",
     "link-assets": "npx react-native-asset",
     "adb": "adb reverse tcp:9090 tcp:9090 && adb reverse tcp:3000 tcp:3000 && adb reverse tcp:9001 tcp:9001 && adb reverse tcp:8081 tcp:8081",

--- a/src/navigation/AudioNavigator/index.tsx
+++ b/src/navigation/AudioNavigator/index.tsx
@@ -20,7 +20,7 @@ import {styles} from './styles';
 
 const AudioStack = createNativeStackNavigator<RootStackParamList>();
 
-const AudioNavigator = (props: any): React.JSX.Element => {
+const AudioNavigator = (): React.JSX.Element => {
   return (
     <AudioStack.Navigator
       initialRouteName="AudiosList"

--- a/src/navigation/AuthNavigator/index.tsx
+++ b/src/navigation/AuthNavigator/index.tsx
@@ -28,7 +28,7 @@ import {styles} from './styles';
 
 const AuthStack = createNativeStackNavigator<RootStackParamList>();
 
-const AuthNavigator = (props: any): React.JSX.Element => {
+const AuthNavigator = (): React.JSX.Element => {
   return (
     <AuthStack.Navigator
       initialRouteName="OnBoarding"
@@ -58,7 +58,7 @@ const AuthNavigator = (props: any): React.JSX.Element => {
           {props => <AuthMethod {...props} />}
         </AuthStack.Screen>
         <AuthStack.Screen name="FirebaseAuthStack">
-          {props => <FirebaseAuthNavigator {...props} />}
+          {() => <FirebaseAuthNavigator />}
         </AuthStack.Screen>
         <AuthStack.Screen name="Login">
           {props => <Login {...props} />}

--- a/src/navigation/DrawerNavigator/index.tsx
+++ b/src/navigation/DrawerNavigator/index.tsx
@@ -37,7 +37,7 @@ import {styles} from './styles';
 
 const Drawer = createDrawerNavigator<RootStackParamList>();
 
-const DrawerNavigator = (props: any): React.JSX.Element => {
+const DrawerNavigator = (): React.JSX.Element => {
   const {colors} = useThemeTokens();
 
   return (
@@ -73,16 +73,16 @@ const DrawerNavigator = (props: any): React.JSX.Element => {
       drawerContent={props => <DrawerMenuContent {...props} />}>
       <Drawer.Group>
         <Drawer.Screen name="TabRoot" options={{title: 'Home'}}>
-          {props => <TabNavigator {...props} />}
+          {() => <TabNavigator />}
         </Drawer.Screen>
         <Drawer.Screen name="Profile">
           {props => <Profile {...props} />}
         </Drawer.Screen>
         <Drawer.Screen name="AudioStack" options={{title: 'Audios'}}>
-          {props => <AudioNavigator {...props} />}
+          {() => <AudioNavigator />}
         </Drawer.Screen>
         <Drawer.Screen name="VideoStack" options={{title: 'Videos'}}>
-          {props => <VideoNavigator {...props} />}
+          {() => <VideoNavigator />}
         </Drawer.Screen>
         <Drawer.Screen name="PostStack" options={{title: 'Social Feed'}}>
           {() => <PostNavigator />}

--- a/src/navigation/FirebaseAuthNavigator/index.tsx
+++ b/src/navigation/FirebaseAuthNavigator/index.tsx
@@ -22,7 +22,7 @@ import {styles} from './styles';
 
 const FirebaseStack = createNativeStackNavigator<RootStackParamList>();
 
-const FirebaseAuthNavigator = (props: any): React.JSX.Element => {
+const FirebaseAuthNavigator = (): React.JSX.Element => {
   return (
     <FirebaseStack.Navigator
       initialRouteName="FirebaseLoginMethod"

--- a/src/navigation/TabNavigator/index.tsx
+++ b/src/navigation/TabNavigator/index.tsx
@@ -36,7 +36,7 @@ interface TabBarIconProps {
 
 const Tab = createBottomTabNavigator<RootStackParamList>();
 
-const TabNavigator = (props: any): React.JSX.Element => {
+const TabNavigator = (): React.JSX.Element => {
   const {t} = useTranslation();
   const {colors} = useTheme();
   const {colors: themeColors} = useThemeTokens();

--- a/src/navigation/VideoNavigator/index.tsx
+++ b/src/navigation/VideoNavigator/index.tsx
@@ -20,7 +20,7 @@ import {styles} from './styles';
 
 const VideoStack = createNativeStackNavigator<RootStackParamList>();
 
-const VideoNavigator = (props: any): React.JSX.Element => {
+const VideoNavigator = (): React.JSX.Element => {
   return (
     <VideoStack.Navigator
       initialRouteName="VideosList"

--- a/src/redux/slices/authSlice.tsx
+++ b/src/redux/slices/authSlice.tsx
@@ -103,11 +103,10 @@ export default authSlice.reducer;
 // can be dispatched like a regular action: `dispatch(incrementAsync(10))`. This
 // will call the thunk with the `dispatch` function as the first argument. Async
 // code can then be executed and other actions can be dispatched
-export const dispatchAddUser = (user: User | null) => (dispatch: any) => {
+import type {AppDispatch} from '@Types/appDispatch';
+
+export const dispatchAddUser = (user: User | null) => (dispatch: AppDispatch) => {
   dispatch(addUser(user));
 };
 
-// The function below is called a selector and allows us to select a value from
-// the state. Selectors can also be defined inline where they're used instead of
-// in the slice file. For example: `useSelector((state) => state.auth.user)`
 export const user = (state: {auth: {user: User | null}}) => state.auth.user;

--- a/src/screens/onboarding/index.tsx
+++ b/src/screens/onboarding/index.tsx
@@ -1,4 +1,3 @@
-//@ts-nocheck Mahmoud need to be checked
 //* packages import
 import React, {useRef} from 'react';
 import {Image, View} from 'react-native';
@@ -11,10 +10,16 @@ import {useThemeTokens} from '@theme/useThemeTokens';
 //* styles import
 import {styles} from './styles';
 
-const OnBoarding = (props: any): React.JSX.Element => {
+import type {AppStackNavigationProp} from '@Types/appNavigation';
+
+interface OnBoardingProps {
+  navigation: AppStackNavigationProp<'OnBoarding'>;
+}
+
+const OnBoarding = ({navigation}: OnBoardingProps): React.JSX.Element => {
   const {t} = useTranslation();
   const {colors} = useThemeTokens();
-  const onBoardingRef = useRef<Onboarding>();
+  const onBoardingRef = useRef<Onboarding | null>(null);
 
   const onOnboardingReady = (ref: Onboarding) => {
     onBoardingRef.current = ref;
@@ -66,7 +71,7 @@ const OnBoarding = (props: any): React.JSX.Element => {
             subtitle: t('onboarding.slide3Subtitle'),
           },
         ]}
-        onDone={() => props.navigation.replace('LoginOptions')}
+        onDone={() => navigation.replace('LoginOptions')}
         containerStyles={styles.onBoardingContainer}
         bottomBarHighlight={false}
         imageContainerStyles={styles.imageOnBoardingContainer}

--- a/src/types/appState.ts
+++ b/src/types/appState.ts
@@ -1,0 +1,3 @@
+import type rootReducer from '@redux/reducers';
+
+export type RootState = ReturnType<typeof rootReducer>;

--- a/src/types/navigationProps.ts
+++ b/src/types/navigationProps.ts
@@ -1,0 +1,18 @@
+import type {DrawerNavigationProp} from '@react-navigation/drawer';
+import type {BottomTabNavigationProp} from '@react-navigation/bottom-tabs';
+import type {NativeStackNavigationProp} from '@react-navigation/native-stack';
+
+import type {DrawerParamList, RootStackParamList} from '@Types/appNavigation';
+
+/** Props passed to stack navigator root components by React Navigation. */
+export type StackNavigatorProps = {
+  navigation: NativeStackNavigationProp<RootStackParamList>;
+};
+
+export type DrawerNavigatorProps = {
+  navigation: DrawerNavigationProp<DrawerParamList>;
+};
+
+export type TabNavigatorProps = {
+  navigation: BottomTabNavigationProp<RootStackParamList>;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Project structure and TypeScript hygiene improvements.

## Changes

- Add **`npm run typecheck`** (`tsc --noEmit`)
- Add **`RootState`** and **`navigationProps`** helper types
- Remove `any` from stack/drawer/tab navigators
- Fix **onboarding** screen types (remove `@ts-nocheck`, fix navigation ref)
- Type **`dispatchAddUser`** with `AppDispatch`
- Use render callbacks without unused prop spreading where navigators ignore props

## Verification

- `npm run typecheck` passes cleanly on this branch
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1aa2-f5cc-71fe-b25d-6da442b36224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1aa2-f5cc-71fe-b25d-6da442b36224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

