### PR TITLE
fix(ci): exclude unused stream-chat from native autolinking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ macOS + Xcode). The runnable development surface in this environment is the **Me
 - Local full pipeline: `npm run ci` (validate i18n → typecheck → lint → test → Android bundle).
 - GitHub Actions: `.github/workflows/ci.yml` on push/PR to `develop` and `master`.
 - Android CI builds **arm64-v8a only**, New Architecture off, ABI splits disabled (`-PenableAbiSplits=false`).
+- `stream-chat-react-native` is excluded from native autolinking (`react-native.config.js`) — unused in `src/` and requires New Arch codegen.
 - Commit `package-lock.json` whenever `package.json` deps change — CI uses `npm install --legacy-peer-deps`.
 - ESLint uses `eslint.config.js` (ESLint 9 flat config, ft-flow plugin removed).
 - Jest smoke tests in `__tests__/smoke.test.ts` (not full App render).

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -4,4 +4,14 @@ module.exports = {
     android: {},
   },
   assets: ['./src/assets/fonts/'],
+  // Chat SDK is a template dependency only (Jest mock); no src/ usage yet.
+  // Its Android native code requires New Architecture codegen and breaks CI with newArchEnabled=false.
+  dependencies: {
+    'stream-chat-react-native': {
+      platforms: {
+        android: null,
+        ios: null,
+      },
+    },
+  },
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Android CI compile failure in `stream-chat-react-native`.

## Error

```
Unresolved reference 'StreamShimmerViewManagerDelegate'
:stream-chat-react-native:compileDebugKotlin FAILED
```

## Fix

Exclude `stream-chat-react-native` from native autolinking — it is not imported anywhere under `src/` (only mocked in Jest) and its Android code requires New Architecture codegen that is disabled in CI.

## Depends on

PR #16 (worklets lockfile, CI Gradle optimizations)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccc74e1b-58a4-4005-ab91-d0a5e7d49413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccc74e1b-58a4-4005-ab91-d0a5e7d49413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

