### PR TITLE
fix(ci): enable New Architecture for Android CMake autolinking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,6 @@ jobs:
           ./gradlew assembleDebug --no-daemon --build-cache --max-workers=2
           -PreactNativeArchitectures=arm64-v8a
           -PenableAbiSplits=false
-          -PnewArchEnabled=false
 
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ macOS + Xcode). The runnable development surface in this environment is the **Me
 ### CI/CD
 - Local full pipeline: `npm run ci` (validate i18n → typecheck → lint → test → Android bundle).
 - GitHub Actions: `.github/workflows/ci.yml` on push/PR to `develop` and `master`.
-- Android CI builds **arm64-v8a only**, New Architecture off, ABI splits disabled (`-PenableAbiSplits=false`).
+- Android CI builds **arm64-v8a only**, ABI splits disabled (`-PenableAbiSplits=false`). New Architecture is **on** (`newArchEnabled=true`) — required for RN 0.85 CMake/codegen autolinking.
 - `stream-chat-react-native` is excluded from native autolinking (`react-native.config.js`) — unused in `src/` and requires New Arch codegen.
 - Commit `package-lock.json` whenever `package.json` deps change — CI uses `npm install --legacy-peer-deps`.
 - ESLint uses `eslint.config.js` (ESLint 9 flat config, ft-flow plugin removed).

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -6,9 +6,9 @@ org.gradle.daemon=true
 android.useAndroidX=true
 android.enableJetifier=true
 
-# React Native — disable New Arch on CI until all native modules are verified
+# React Native — New Arch required for RN 0.85 CMake autolinking (codegen jni dirs)
 hermesEnabled=true
-newArchEnabled=false
+newArchEnabled=true
 
 # Kotlin
 kotlin.code.style=official


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `configureCMakeDebug[arm64-v8a]` failure when New Architecture is disabled.

## Error

```
add_subdirectory given source ".../geolocation/.../codegen/jni/" which is not an existing directory
Cannot specify link libraries for target "react_codegen_RNCGeolocationSpec"
```

## Fix

Set `newArchEnabled=true` in `gradle.properties` so RN 0.85 generates required codegen JNI directories. CI remains optimized with arm64-only builds and disabled ABI splits.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccc74e1b-58a4-4005-ab91-d0a5e7d49413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccc74e1b-58a4-4005-ab91-d0a5e7d49413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

