### PR TITLE
docs: New Architecture is mandatory, never disable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,9 @@ macOS + Xcode). The runnable development surface in this environment is the **Me
 ### CI/CD
 - Local full pipeline: `npm run ci` (validate i18n → typecheck → lint → test → Android bundle).
 - GitHub Actions: `.github/workflows/ci.yml` on push/PR to `develop` and `master`.
-- Android CI builds **arm64-v8a only**, ABI splits disabled (`-PenableAbiSplits=false`). New Architecture is **on** (`newArchEnabled=true`) — required for RN 0.85 CMake/codegen autolinking.
-- `stream-chat-react-native` is excluded from native autolinking (`react-native.config.js`) — unused in `src/` and requires New Arch codegen.
+- **New Architecture must always stay enabled** — Android: `newArchEnabled=true` in `android/gradle.properties`; iOS: `RCTNewArchEnabled` in `Info.plist`. Never disable for CI or local builds.
+- Android CI builds **arm64-v8a only** with ABI splits disabled (`-PenableAbiSplits=false`) for runner time; this does not affect New Architecture.
+- `stream-chat-react-native` is excluded from native autolinking (`react-native.config.js`) — unused in `src/` (Jest mock only).
 - Commit `package-lock.json` whenever `package.json` deps change — CI uses `npm install --legacy-peer-deps`.
 - ESLint uses `eslint.config.js` (ESLint 9 flat config, ft-flow plugin removed).
 - Jest smoke tests in `__tests__/smoke.test.ts` (not full App render).

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.daemon=true
 android.useAndroidX=true
 android.enableJetifier=true
 
-# React Native — New Arch required for RN 0.85 CMake autolinking (codegen jni dirs)
+# React Native — New Architecture is mandatory; do not set newArchEnabled=false
 hermesEnabled=true
 newArchEnabled=true
 

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -5,7 +5,6 @@ module.exports = {
   },
   assets: ['./src/assets/fonts/'],
   // Chat SDK is a template dependency only (Jest mock); no src/ usage yet.
-  // Its Android native code requires New Architecture codegen and breaks CI with newArchEnabled=false.
   dependencies: {
     'stream-chat-react-native': {
       platforms: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Documents that New Architecture must always remain enabled on Android and iOS. No functional change — `newArchEnabled=true` and `RCTNewArchEnabled` were already set.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccc74e1b-58a4-4005-ab91-d0a5e7d49413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccc74e1b-58a4-4005-ab91-d0a5e7d49413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

