### PR TITLE
fix(islamic): resolve CodeRabbit comments on develop→master (#26)

### DIFF
--- a/src/components/organisms/islamic/IslamicNotificationHost.tsx
+++ b/src/components/organisms/islamic/IslamicNotificationHost.tsx
@@ -9,7 +9,10 @@ import {
 } from '@helpers/prayerLocationHelpers';
 import {useAppSelector} from '@hooks/useAppSelector';
 import {refreshIslamicNotificationSchedule} from '@services/islamicServices/islamicNotificationService';
-import {syncPrayerReminderNotifications} from '@services/islamicServices/prayerNotificationService';
+import {
+  cancelPrayerReminderNotifications,
+  syncPrayerReminderNotifications,
+} from '@services/islamicServices/prayerNotificationService';
 
 /**
  * Keeps finite-horizon Islamic + prayer notification schedules fresh on mount,
@@ -31,6 +34,9 @@ const IslamicNotificationHost = (): null => {
       prayerReminders.enabledAll ||
       PRAYER_ADHAN_KEYS.some(key => prayerReminders.byKey[key]);
     if (!anyPrayerEnabled || !isPrayerLocationConfigured(location)) {
+      // Cancellation lives inside sync — call it explicitly on the disable path
+      // so previously scheduled Adhan reminders do not keep firing.
+      cancelPrayerReminderNotifications().catch(() => undefined);
       return;
     }
     syncPrayerReminderNotifications({

--- a/src/screens/islamic/prayerTimes/index.tsx
+++ b/src/screens/islamic/prayerTimes/index.tsx
@@ -86,13 +86,16 @@ const PrayerTimes = ({navigation}: Props): React.JSX.Element => {
 
   const {data, isLoading, isError, isFetching} = useCoords ? coordsQuery : cityQuery;
 
-  const browseSelectedDay = useCallback((delta: number) => {
-    setSelectedDay(current => {
-      const next = addCalendarDays(current, delta);
+  const browseSelectedDay = useCallback(
+    (delta: number) => {
+      // Keep the state updater pure — React may invoke it more than once
+      // (e.g. Strict Mode). Update the tracking ref outside setState.
+      const next = addCalendarDays(selectedDay, delta);
       trackingTodayRef.current = isSameLocalDay(next, new Date());
-      return next;
-    });
-  }, []);
+      setSelectedDay(next);
+    },
+    [selectedDay],
+  );
 
   useEffect(() => {
     const id = setInterval(() => setNow(new Date()), 1000);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Addresses the latest CodeRabbit review on [PR #26](https://github.com/M-Albasti/RNTS-Template/pull/26) (`develop` → `master`).

### Inline (fixed)
1. **`IslamicNotificationHost`** — when prayer reminders are disabled or location is unset, explicitly call `cancelPrayerReminderNotifications()` so previously scheduled Adhan notifications stop firing.
2. **`prayerTimes` `browseSelectedDay`** — keep the `setSelectedDay` updater pure (no ref writes inside the updater). Fixes the React Doctor / Strict Mode re-render side-effect CodeRabbit flagged.

### Outside diff (`estimatedItemSize` on Hadith FlashLists)
**Skipped intentionally.** The project uses `@shopify/flash-list` **v2.3.x**, which removed `estimatedItemSize` (“no size estimates required”). Adding the prop fails TypeScript (`Property 'estimatedItemSize' does not exist on FlashListProps`). The lists already use `drawDistance={600}` for recycle windowing.

## Test plan
- [ ] Disable all prayer reminders → previously scheduled Adhan notifications are cleared
- [ ] Clear/unset prayer location → same cancellation path runs
- [ ] Prayer Times date prev/next still advances the calendar and “today tracking” behaves correctly
- [ ] `npm run typecheck` / smoke tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1aa2-f5cc-71fe-b25d-6da442b36224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1aa2-f5cc-71fe-b25d-6da442b36224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

